### PR TITLE
fix considering wait_for as relevant task

### DIFF
--- a/apimon/ansible/callback/apimon_profiler.py
+++ b/apimon/ansible/callback/apimon_profiler.py
@@ -234,8 +234,12 @@ class CallbackModule(CallbackBase):
                 or task.action.startswith('openstack')
                 # This is bad, but what else can we do?
                 or task.action[:3] in ['rds', 'cce']
-                or task.action in ('script', 'command',
-                                   'wait_for_connection', 'wait_for')
+                or task.action in (
+                    'script', 'ansible.builtin.script',
+                    'command', 'ansible.builtint.command',
+                    'wait_for_connection',
+                    'ansible.builtin.wait_for_connection',
+                    'wait_for', 'ansible.builtin.wait_for')
             )
         )
 

--- a/releasenotes/notes/fix-wait-for-ed7d66655797d41e.yaml
+++ b/releasenotes/notes/fix-wait-for-ed7d66655797d41e.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Rebase to OTCE 0.22 to make use of the repaired CCE project cleanup
+fixes:
+  - |
+    For selected ansible modules (in the is_interesting comarison) use also FQCN.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible==4.2.0
+ansible==4.4.0
 gear
-otcextensions==0.19.0
+otcextensions==0.22.0
 openstacksdk
 GitPython
 statsd


### PR DESCRIPTION
- ansible may report into the callback plugin FQCN names. Extend the
  `is_intersting` check with FQCN names.
- update to otce 0.22.0 to repair cce project cleanup
