### PR TITLE
install ACCs into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,10 @@ RUN cd apimon && python3 setup.py install
 
 RUN rm -rf /usr/app/{ansible,apimon,python-otcextensions}
 
+RUN su - apimon -c 'ansible-galaxy collection install opentelekomcloud.cloud \
+  && ansible-galaxy collection install \
+     git+https://opendev.org/openstack/ansible-collections-openstack'
+
 USER apimon
 
 ENV HOME=/home/apimon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-ansible==6.4.0
+ansible==6.6.0
 gear
 otcextensions
 #openstacksdk==0.61.0
-openstacksdk==0.102.0
+openstacksdk==0.103.0
 GitPython
 statsd
 influxdb


### PR DESCRIPTION
while there is no ansible-collection-openstack release supporting latest openstack we need to hardly install it into the image, since ansible-galaxy does not support installing collection from galaxy depending on the collection from git